### PR TITLE
Update NAMESPACE: spatstat to spatstat.geom

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -21,7 +21,7 @@ importFrom(mvtnorm, dmvnorm, pmvnorm, rmvnorm)
 importFrom(polyCub, polyCub.SV)
 importFrom(rgl,points3d, lines3d, polygon3d, axes3d, title3d)
 importFrom(sm,sm.density)
-importFrom(spatstat, area, owin, is.empty, is.owin)
+importFrom(spatstat.geom, area, owin, is.empty, is.owin)
 importFrom(grDevices, chull, contourLines)
 importFrom(stats, dnorm, nlm, rnorm, runif, sd,
             weighted.mean)


### PR DESCRIPTION
Due to an update of `spatstat` package, the objects `area`, `owin`, `is.empty` and `is.owin` are now part of the sub-package `spatstat.geom`.